### PR TITLE
Issue #81 (retter opp datofeil på forsiden)

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -19,7 +19,7 @@ include::locale/attributes.adoc[]
 
 image::images/digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
-*Publisert*: 2020-03-15 (v.2.0) +
+*Publisert*: 2019-03-15 (v.2.0) +
 *Oppdatert*: 2020-07-01 (v.2.0.2) +
 *Status*: Gjeldende
 


### PR DESCRIPTION
Kun for å rette opp en skrivefeil på forsiden. Denne går rett ut til den offisielle versjonen av standarden under data.norge.no/specification. 