### PR TITLE
fix: add explicit permissions to workflows

### DIFF
--- a/.github/workflows/adocs-build-and-publish-develop.yml
+++ b/.github/workflows/adocs-build-and-publish-develop.yml
@@ -8,6 +8,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   adoc_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/adocs-build-and-publish-v1-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v1-production.yml
@@ -8,6 +8,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   adoc_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/adocs-build-and-publish-v1-staging.yml
+++ b/.github/workflows/adocs-build-and-publish-v1-staging.yml
@@ -8,6 +8,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   adoc_build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary 

- Add `permissions: contents: write` to develop workflow (gh-pages deploy)
- Add `permissions: contents: read` to v1 staging and production workflows
- Resolves CodeQL alerts ("Workflow does not contain permissions")